### PR TITLE
style: 헤터 버튼 반응형 수정

### DIFF
--- a/src/components/sections/Header.jsx
+++ b/src/components/sections/Header.jsx
@@ -1,6 +1,7 @@
 import {useState} from 'react';
 import AppsIcon from '../../assets/header/appsIcon.svg';
 import TreeIcon from '../../assets/header/tree.svg';
+import ShareIcon from '../../assets/project-detail/share.svg';
 
 export default function Header() {
   const [showShareMenu, setShowShareMenu] = useState(false);
@@ -55,9 +56,13 @@ export default function Header() {
       </div>
       <div className='font-pretendard flex items-center gap-2 font-medium text-[#FFFFFF] md:gap-3.5 md:font-semibold'>
         <div className='relative'>
+          <button onClick={handleShare} className='md:hidden'>
+            <img src={ShareIcon} alt='공유하기' className='h-6 w-6' />
+          </button>
+
           <button
             onClick={handleShare}
-            className='rounded-full border border-white px-3 py-1 text-xs transition-colors hover:bg-white/10 md:px-5 md:py-1.5 md:text-sm'>
+            className='hidden rounded-full border border-white px-3 py-1 text-xs transition-colors hover:bg-white/10 md:block md:px-5 md:py-1.5 md:text-sm'>
             {copySuccess ? '링크 복사됨!' : '링크 공유하기'}
           </button>
           {showShareMenu && (
@@ -70,7 +75,7 @@ export default function Header() {
             </div>
           )}
         </div>
-        <button className='rounded-full border border-white px-3 py-1 text-xs transition-colors hover:bg-white/10 md:px-5 md:py-1.5 md:text-sm'>
+        <button className='hidden rounded-full border border-white px-3 py-1 text-xs transition-colors hover:bg-white/10 md:block md:px-5 md:py-1.5 md:text-sm'>
           13기 알림 신청하기
         </button>
         <a


### PR DESCRIPTION

## 작업 요약
헤더의 버튼들이 모바일일 때 숨김 처리 및 다른 아이콘으로 대체되게 함

---

## 변경 사항
다른 버튼들 md 시 block
hidden 기본값
아이콘은 md시 hidden

---

## 스크린샷
<img width="350" height="477" alt="image" src="https://github.com/user-attachments/assets/eb589d25-6453-4f52-8317-72213019998a" />


---

## 이슈 연결

Closes #44

---

## 체크리스트

- [ ] 스크린샷 또는 GIF 첨부
- [ ] 주요 플로우 직접 테스트 완료
- [ ] 불필요한 콘솔 로그 제거
- [ ] 관련 없는 파일 변경 없음

---

## 참고 사항
