### PR TITLE
style: 카드와 프레임이미지 간격 조정

### DIFF
--- a/src/components/sections/Activities.jsx
+++ b/src/components/sections/Activities.jsx
@@ -63,7 +63,7 @@ export default function Activities() {
         </div>
       </div>
 
-      <div className='relative h-[282px]'>
+      <div className='relative h-[20vw]'>
         <img
           src={UnionIcon}
           className='absolute z-20 mx-37 -mt-10 scale-60 sm:scale-90 md:mx-53 md:-mt-12 md:scale-80'


### PR DESCRIPTION
Refs #50


## 작업 요약

액티비티 섹션의 카드와 아래 프레임이미지 간격이 모바일에서 너무 벌어지는 것을 조정함

---

## 변경 사항
h를 고정이 아닌 비례해 줄어들도록 함
---

## 스크린샷
<img width="411" height="727" alt="image" src="https://github.com/user-attachments/assets/94f902da-8cca-4a05-9bc1-f7e4a5f1e30e" />

---

## 이슈 연결
Closes #50

---

## 체크리스트

- [ ] 스크린샷 또는 GIF 첨부
- [ ] 주요 플로우 직접 테스트 완료
- [ ] 불필요한 콘솔 로그 제거
- [ ] 관련 없는 파일 변경 없음

---

## 참고 사항

